### PR TITLE
enable interpretation of backslash escapes

### DIFF
--- a/configs/git/git-st
+++ b/configs/git/git-st
@@ -39,5 +39,5 @@ do
 done
 if [ $(( ${#status[@]} - 1)) -eq 0 ]
 then
-    echo "\033[93mNothing to commit, working tree clean\033[0m"
+    echo -e "\033[93mNothing to commit, working tree clean\033[0m"
 fi


### PR DESCRIPTION
For `echo` on my system (CentOS 7, GNU bash, version 4.2.46(2)-release (x86_64-redhat-linux-gnu)), interpretation of backslash escapes is disabled by default and requires the `-e` flag to enable.

If this doesn't break the script on your system, consider merging the change so others can use the script without modifications.